### PR TITLE
DMA updates

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -674,13 +674,74 @@ impl SoundStatusMaster {
   }
 }
 
-newtype! {
+newtype_enum! {
+  /// Controls the change in DMA destination address
+  DestAddressControl = u16,
+  #[allow(missing_docs)]
+  Increment = 0,
+  #[allow(missing_docs)]
+  Decrement = 1,
+  #[allow(missing_docs)]
+  Fixed = 2,
+  #[allow(missing_docs)]
+  IncrementReload = 3,
+}
+
+#[allow(missing_docs)]
+newtype_enum! {
+  /// Controls the change in DMA source address
+  SourceAddressControl = u16,
+  #[allow(missing_docs)]
+  Increment = 0,
+  #[allow(missing_docs)]
+  Decrement = 1,
+  #[allow(missing_docs)]
+  Fixed = 2,
+}
+
+#[allow(missing_docs)]
+newtype_enum! {
+  /// Controls DMA starting time
+  StartTiming = u16,
+  /// This actually takes 2 clock cycles
+  Immediately = 0,
+  /// Trigger on VBlank
+  VBlank = 1,
+  /// Trigger on HBlank
+  HBlank = 2,
+  /// Varies by DMA unit:
   ///
+  /// * 0: Prohibited
+  /// * 1 or 2: Sound FIFO
+  /// * 3: Video Capture
+  Special = 3,
+}
+
+newtype! {
+  /// Configures a DMA unit.
+  ///
+  /// * 5-6: destination address control
+  /// * 7-8: source address control
+  /// * 9: DMA repeat
+  /// * 10: DMA transfer type
+  /// * 12-13: DMA start timing
+  /// * 14: Interrupt when DMA ends
+  /// * 15: DMA Enable
+  ///
+  /// DRQ is only for special game pak units, and so it isn't supported by this
+  /// type.
   DMAControl, u16
 }
 #[allow(missing_docs)]
 impl DMAControl {
   phantom_fields! {
     self.0: u16,
+    dest_address_ctrl: 5-6=DestAddressControl<Increment, Decrement, Fixed, IncrementReload>,
+    src_address_ctrl: 7-8=SourceAddressControl<Increment, Decrement, Fixed>,
+    dma_repeats: 9,
+    dma_is_32bit: 10,
+    dma_start_time: 12-13=StartTiming<Immediately, VBlank, HBlank, Special>,
+    irq_at_end: 14,
+    dma_enable: 15,
   }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -45,7 +45,7 @@ newtype_enum! {
 }
 
 newtype!(
-  /// Setting for the display control register.
+  /// Configuration for the display control register.
   ///
   /// * 0-2: `DisplayMode`
   /// * 3: CGB mode flag
@@ -61,11 +61,11 @@ newtype!(
   /// * 13: Window 0 display
   /// * 14: Window 1 display
   /// * 15: Object window
-  DisplayControlSetting,
+  DisplayControl,
   u16
 );
 #[allow(missing_docs)]
-impl DisplayControlSetting {
+impl DisplayControl {
   phantom_fields! {
     self.0: u16,
     mode: 0-2=DisplayMode<Mode0, Mode1, Mode2, Mode3, Mode4, Mode5>,
@@ -97,11 +97,11 @@ newtype!(
   ///
   /// "Although the drawing time is only 960 cycles (240*4), the H-Blank flag is
   /// "0" for a total of 1006 cycles." -gbatek
-  DisplayStatusSetting,
+  DisplayStatus,
   u16
 );
 #[allow(missing_docs)]
-impl DisplayStatusSetting {
+impl DisplayStatus {
   phantom_fields! {
     self.0: u16,
     vblank_flag: 0,
@@ -124,10 +124,10 @@ newtype! {
   /// Bit 8-12: Screen Base Block (0 through 31, 2k each)
   /// Bit 13: Display area overflow wraps (otherwise transparent, affine BG only)
   /// Bit 14-15: Screen Size (details depend on Text/Affine mode)
-  BackgroundControlSetting, u16
+  BackgroundControl, u16
 }
 #[allow(missing_docs)]
-impl BackgroundControlSetting {
+impl BackgroundControl {
   phantom_fields! {
     self.0: u16,
     bg_priority: 0-1,
@@ -156,10 +156,10 @@ newtype! {
   /// * Bits 4-7: BG mosaic vertical increase
   /// * Bits 8-11: Object mosaic horizontal increase
   /// * Bits 12-15: Object mosaic vertical increase
-  MosaicSetting, u16
+  Mosaic, u16
 }
 #[allow(missing_docs)]
-impl MosaicSetting {
+impl Mosaic {
   phantom_fields! {
     self.0: u16,
     bg_horizontal_inc: 0-3,
@@ -194,10 +194,10 @@ newtype! {
   ///
   /// * x1: Leftmost window edge (8-bit)
   /// * x2: Rightmost window edge +1 (8-bit)
-  WindowHorizontalSetting, u16
+  WindowHorizontal, u16
 }
 #[allow(missing_docs)]
-impl WindowHorizontalSetting {
+impl WindowHorizontal {
   phantom_fields! {
     self.0: u16,
     x1: 8-15,
@@ -210,10 +210,10 @@ newtype! {
   ///
   /// * y1: Leftmost window edge (8-bit)
   /// * y2: Rightmost window edge +1 (8-bit)
-  WindowVerticalSetting, u16
+  WindowVertical, u16
 }
 #[allow(missing_docs)]
-impl WindowVerticalSetting {
+impl WindowVertical {
   phantom_fields! {
     self.0: u16,
     y1: 8-15,
@@ -230,10 +230,10 @@ newtype! {
   /// * 8-11: Win0 BG0 through BG3 enable
   /// * 12: Win0 OBJ enable
   /// * 13: Win0 color special effect enable
-  WindowInSetting, u16
+  WindowIn, u16
 }
 #[allow(missing_docs)]
-impl WindowInSetting {
+impl WindowIn {
   phantom_fields! {
     self.0: u16,
     win0_bg0: 0,
@@ -260,10 +260,10 @@ newtype! {
   /// * 8-11: OBJ Window BG0 through BG3 enable
   /// * 12: OBJ Window OBJ enable
   /// * 13: OBJ Window color special effect enable
-  WindowOutSetting, u16
+  WindowOut, u16
 }
 #[allow(missing_docs)]
-impl WindowOutSetting {
+impl WindowOut {
   phantom_fields! {
     self.0: u16,
     outside_bg0: 0,
@@ -307,10 +307,10 @@ newtype! {
   ///
   /// For the names, note that BD = Backdrop (the color when nothing at all is
   /// drawn from any background or object).
-  BlendControlSetting, u16
+  BlendControl, u16
 }
 #[allow(missing_docs)]
-impl BlendControlSetting {
+impl BlendControl {
   phantom_fields! {
     self.0: u16,
     bg0_1st_target: 0,
@@ -342,10 +342,10 @@ newtype! {
   /// If the blend mode isn't set to `AlphaBlend`, or if the 1st target and 2nd
   /// target combination isn't valid for this pixel location then this register
   /// has no effect at all.
-  BlendAlphaSetting, u16
+  BlendAlpha, u16
 }
 #[allow(missing_docs)]
-impl BlendAlphaSetting {
+impl BlendAlpha {
   phantom_fields! {
     self.0: u16,
     eva_coefficient: 0-4,
@@ -366,10 +366,10 @@ newtype! {
   ///
   /// If the blend mode isn't set to `BrightnessIncrease` or
   /// `BrightnessDecrease` this register has no effect at all.
-  BlendBrightnessSetting, u16
+  BlendBrightness, u16
 }
 #[allow(missing_docs)]
-impl BlendBrightnessSetting {
+impl BlendBrightness {
   phantom_fields! {
     self.0: u16,
     evy_coefficient: 0-4,
@@ -385,10 +385,10 @@ newtype! {
   ///
   /// If sweep is disabled by setting sweep time to 0, the sweep should also be
   /// set to decreasing mode.
-  SweepSetting, u8
+  Sweep, u8
 }
 #[allow(missing_docs)]
-impl SweepSetting {
+impl Sweep {
   phantom_fields! {
     self.0: u8,
     shift_num: 0-2,
@@ -418,10 +418,10 @@ newtype! {
   /// * 8-10: Time per envelope step: `x/64` sec, or 0 for no envelope.
   /// * 11: If the envelope is increasing or decreasing.
   /// * 12-15: Initial envelope volume (0 = no sound)
-  DutyLenEnvelopeSetting, u16
+  DutyLenEnvelope, u16
 }
 #[allow(missing_docs)]
-impl DutyLenEnvelopeSetting {
+impl DutyLenEnvelope {
   phantom_fields! {
     self.0: u16,
     length: 0-5,
@@ -438,10 +438,10 @@ newtype! {
   /// * 0-10 (wo): Frequency `131072/(2048-n)` Hz
   /// * 14: Stop output when length expires
   /// * 15 (wo): Initialize/restart this sound
-  PulseFrequencyControlSetting, u16
+  PulseFrequencyControl, u16
 }
 #[allow(missing_docs)]
-impl PulseFrequencyControlSetting {
+impl PulseFrequencyControl {
   phantom_fields! {
     self.0: u16,
     frequency: 0-10,
@@ -488,10 +488,10 @@ newtype! {
   /// * 0-7 (wo): Sound Length: `(256-n)/256` seconds
   /// * 13-14: Volume Mode
   /// * 15: Override above and use 75%
-  WaveLengthVolumeSetting, u16
+  WaveLengthVolume, u16
 }
 #[allow(missing_docs)]
-impl WaveLengthVolumeSetting {
+impl WaveLengthVolume {
   phantom_fields! {
     self.0: u16,
     length: 0-7,
@@ -525,10 +525,10 @@ newtype! {
   /// * 8-10: Envelope step time, `n/64` seconds, 0 for off.
   /// * 11: Envelope increasing
   /// * 12-15: Envelope initial volume
-  LengthEnvelopeSetting, u16
+  LengthEnvelope, u16
 }
 #[allow(missing_docs)]
-impl LengthEnvelopeSetting {
+impl LengthEnvelope {
   phantom_fields! {
     self.0: u16,
     length: 0-5,
@@ -564,7 +564,7 @@ impl NoiseFrequencyControl {
 
 newtype! {
   /// Allows setting of the `SOUNDBIAS` register.
-  /// 
+  ///
   /// * 1-9: Bias level, defaults to 0x100
   /// * 14-15: Amplitude resolution: 9 bits _minus_ this value.
   Soundbias, u16
@@ -580,7 +580,7 @@ impl Soundbias {
 
 newtype! {
   /// Controls left and right sound outputs.
-  /// 
+  ///
   /// * 0-2: Master Right Volume
   /// * 4-6: Master Left Volume
   /// * 8: Pulse A right
@@ -623,7 +623,7 @@ newtype_enum! {
 
 newtype! {
   /// Controls DMA Sound mixing.
-  /// 
+  ///
   /// * 0-1: non-dma sound level: quarter, half, or full.
   /// * 2: DMA sound A full (true) or half (false)
   /// * 3: DMA sound B full (true) or half (false)
@@ -651,13 +651,13 @@ impl DMAMixer {
     dma_b_right: 12,
     dma_b_left: 13,
     dma_b_timer1: 14,
-    dma_b_reset_fifo: 15, 
+    dma_b_reset_fifo: 15,
   }
 }
 
 newtype! {
   /// Allows setting of the `SOUND_STATUS_ENABLE` register.
-  /// 
+  ///
   /// * 0 (ro): Pulse A is active
   /// * 1 (ro): Pulse B is active
   /// * 2 (ro): Wave is active
@@ -671,5 +671,16 @@ impl SoundStatusMaster {
     self.0: u16,
     bias_level: 1-9,
     amplitude_resolution: 14-15,
+  }
+}
+
+newtype! {
+  ///
+  DMAControl, u16
+}
+#[allow(missing_docs)]
+impl DMAControl {
+  phantom_fields! {
+    self.0: u16,
   }
 }

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -17,3 +17,6 @@ pub use lcd::*;
 
 mod sound;
 pub use sound::*;
+
+mod dma;
+pub use dma::*;

--- a/src/mmio/dma.rs
+++ b/src/mmio/dma.rs
@@ -1,0 +1,92 @@
+
+use super::*;
+
+/// Only uses the least significant 27 bits of the address
+pub const DMA0_SOURCE: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0B0) };
+
+/// Only uses the least significant 27 bits of the address
+pub const DMA0_DEST: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0B4) };
+
+/// How many _units_ to transfer (either 16-bit or 32-bit). 0 instead indicates 0x4000.
+pub const DMA0_COUNT: WOVolAddress<u16> = unsafe { WOVolAddress::new(0x4_000_0B8) };
+
+/// Reads the DMA0 control register (always safe to read).
+pub const DMA0_CONTROL: ROVolAddress<DMAControl> = unsafe { ROVolAddress::new(0x4_000_0BA) };
+
+/// Writes to the DMA0 control register.
+///
+/// # Safety
+///
+/// You must follow all of the DMA rules outlined in
+/// [GBATEK](https://problemkaputt.de/gbatek.htm#gbadmatransfers), and you must
+/// also not use DMA to alter any memory that is currently pointed to by a
+/// shared reference (`&T`), unique reference (`&mut T`), or const pointer
+/// (`*const T`). Memory that is currently pointed to by a mut pointer (`*mut
+/// T`) is _likely_ fine to alter, though Rust's exact semantics in this area
+/// are honestly a little fuzzy.
+pub unsafe fn set_dma0_control(ctrl: DMAControl) {
+  VolAddress::new(DMA0_CONTROL.to_usize()).write(ctrl)
+}
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA1_SOURCE: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0BC) };
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA1_DEST: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0C0) };
+
+/// How many _units_ to transfer (either 16-bit or 32-bit). 0 instead indicates 0x1_0000.
+pub const DMA1_COUNT: WOVolAddress<u16> = unsafe { WOVolAddress::new(0x4_000_0C4) };
+
+/// Reads the DMA1 control register (always safe to read).
+pub const DMA1_CONTROL: VolAddress<DMAControl> = unsafe { VolAddress::new(0x4_000_0C6) };
+
+/// Writes to the DMA1 control register.
+///
+/// # Safety
+///
+/// As per `set_dma0_control`
+pub unsafe fn set_dma1_control(ctrl: DMAControl) {
+  VolAddress::new(DMA1_CONTROL.to_usize()).write(ctrl)
+}
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA2_SOURCE: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0C8) };
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA2_DEST: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0CC) };
+
+/// How many _units_ to transfer (either 16-bit or 32-bit). 0 instead indicates 0x1_0000.
+pub const DMA2_COUNT: WOVolAddress<u16> = unsafe { WOVolAddress::new(0x4_000_0D0) };
+
+/// Reads the DMA2 control register (always safe to read).
+pub const DMA2_CONTROL: VolAddress<DMAControl> = unsafe { VolAddress::new(0x4_000_0D2) };
+
+/// Writes to the DMA2 control register.
+///
+/// # Safety
+///
+/// As per `set_dma0_control`
+pub unsafe fn set_dma2_control(ctrl: DMAControl) {
+  VolAddress::new(DMA2_CONTROL.to_usize()).write(ctrl)
+}
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA3_SOURCE: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0D4) };
+
+/// Only uses the least significant 28 bits of the address
+pub const DMA3_DEST: WOVolAddress<*mut u32> = unsafe { WOVolAddress::new(0x4_000_0D8) };
+
+/// How many _units_ to transfer (either 16-bit or 32-bit). 0 instead indicates 0x1_0000.
+pub const DMA3_COUNT: WOVolAddress<u16> = unsafe { WOVolAddress::new(0x4_000_0DC) };
+
+/// Reads the DMA3 control register (always safe to read).
+pub const DMA3_CONTROL: VolAddress<DMAControl> = unsafe { VolAddress::new(0x4_000_0DE) };
+
+/// Writes to the DMA3 control register.
+///
+/// # Safety
+///
+/// As per `set_dma0_control`
+pub unsafe fn set_dma3_control(ctrl: DMAControl) {
+  VolAddress::new(DMA3_CONTROL.to_usize()).write(ctrl)
+}

--- a/src/mmio/lcd.rs
+++ b/src/mmio/lcd.rs
@@ -4,13 +4,13 @@ use super::*;
 /// The core display control register.
 ///
 /// Sets the visual mode as well as which layers to display.
-pub const DISPCNT: VolAddress<DisplayControlSetting> = unsafe { VolAddress::new(0x400_0000) };
+pub const DISPCNT: VolAddress<DisplayControl> = unsafe { VolAddress::new(0x400_0000) };
 
 /// Display status and interrupt control register.
 ///
 /// This is only partly read/write, some fields are read only, see the setting
 /// type for more info.
-pub const DISPSTAT: VolAddress<DisplayStatusSetting> = unsafe { VolAddress::new(0x400_0004) };
+pub const DISPSTAT: VolAddress<DisplayStatus> = unsafe { VolAddress::new(0x400_0004) };
 
 /// The current scanline being processed.
 ///
@@ -18,16 +18,16 @@ pub const DISPSTAT: VolAddress<DisplayStatusSetting> = unsafe { VolAddress::new(
 pub const VCOUNT: ROVolAddress<u16> = unsafe { ROVolAddress::new(0x400_0006) };
 
 /// Configuration for BG0
-pub const BG0CNT: VolAddress<BackgroundControlSetting> = unsafe { VolAddress::new(0x400_0008) };
+pub const BG0CNT: VolAddress<BackgroundControl> = unsafe { VolAddress::new(0x400_0008) };
 
 /// Configuration for BG1
-pub const BG1CNT: VolAddress<BackgroundControlSetting> = unsafe { VolAddress::new(0x400_000A) };
+pub const BG1CNT: VolAddress<BackgroundControl> = unsafe { VolAddress::new(0x400_000A) };
 
 /// Configuration for BG2
-pub const BG2CNT: VolAddress<BackgroundControlSetting> = unsafe { VolAddress::new(0x400_000C) };
+pub const BG2CNT: VolAddress<BackgroundControl> = unsafe { VolAddress::new(0x400_000C) };
 
 /// Configuration for BG3
-pub const BG3CNT: VolAddress<BackgroundControlSetting> = unsafe { VolAddress::new(0x400_000E) };
+pub const BG3CNT: VolAddress<BackgroundControl> = unsafe { VolAddress::new(0x400_000E) };
 
 /// Leftmost visible BG0 pixel (9-bits, tiled mode only).
 pub const BG0HOFS: WOVolAddress<u16> = unsafe { WOVolAddress::new(0x400_0010) };
@@ -90,31 +90,31 @@ pub const BG3X: WOVolAddress<FP_I_19_8> = unsafe { WOVolAddress::new(0x400_0038)
 pub const BG3Y: WOVolAddress<FP_I_19_8> = unsafe { WOVolAddress::new(0x400_003C) };
 
 /// Horizontal position of Win0
-pub const WIN0H: WOVolAddress<WindowHorizontalSetting> = unsafe { WOVolAddress::new(0x400_0040) };
+pub const WIN0H: WOVolAddress<WindowHorizontal> = unsafe { WOVolAddress::new(0x400_0040) };
 
 /// Horizontal position of Win1
-pub const WIN1H: WOVolAddress<WindowHorizontalSetting> = unsafe { WOVolAddress::new(0x400_0042) };
+pub const WIN1H: WOVolAddress<WindowHorizontal> = unsafe { WOVolAddress::new(0x400_0042) };
 
 /// Vertical position of Win0
-pub const WIN0V: WOVolAddress<WindowVerticalSetting> = unsafe { WOVolAddress::new(0x400_0044) };
+pub const WIN0V: WOVolAddress<WindowVertical> = unsafe { WOVolAddress::new(0x400_0044) };
 
 /// Vertical position of Win1
-pub const WIN1V: WOVolAddress<WindowVerticalSetting> = unsafe { WOVolAddress::new(0x400_0046) };
+pub const WIN1V: WOVolAddress<WindowVertical> = unsafe { WOVolAddress::new(0x400_0046) };
 
 /// Controls the appearance inside of Window0 and Window1
-pub const WININ: VolAddress<WindowInSetting> = unsafe { VolAddress::new(0x400_0048) };
+pub const WININ: VolAddress<WindowIn> = unsafe { VolAddress::new(0x400_0048) };
 
 /// Controls the appearance Outside of Windows and of the OBJ Window
-pub const WINOUT: VolAddress<WindowOutSetting> = unsafe { VolAddress::new(0x400_004A) };
+pub const WINOUT: VolAddress<WindowOut> = unsafe { VolAddress::new(0x400_004A) };
 
 /// Allows control of the mosaic effect.
-pub const MOSAIC: WOVolAddress<MosaicSetting> = unsafe { WOVolAddress::new(0x400_004C) };
+pub const MOSAIC: WOVolAddress<Mosaic> = unsafe { WOVolAddress::new(0x400_004C) };
 
 /// Overall configuration of color blending (see also `BLDALPHA` and `BLDY`)
-pub const BLDCNT: VolAddress<BlendControlSetting> = unsafe { VolAddress::new(0x400_0050) };
+pub const BLDCNT: VolAddress<BlendControl> = unsafe { VolAddress::new(0x400_0050) };
 
 /// Configures alpha blending.
-pub const BLDALPHA: VolAddress<BlendAlphaSetting> = unsafe { VolAddress::new(0x400_0052) };
+pub const BLDALPHA: VolAddress<BlendAlpha> = unsafe { VolAddress::new(0x400_0052) };
 
 /// Configures brightness blending.
-pub const BLDY: WOVolAddress<BlendBrightnessSetting> = unsafe { WOVolAddress::new(0x400_0054) };
+pub const BLDY: WOVolAddress<BlendBrightness> = unsafe { WOVolAddress::new(0x400_0054) };

--- a/src/mmio/sound.rs
+++ b/src/mmio/sound.rs
@@ -5,24 +5,22 @@ use typenum::consts::U8;
 //
 
 /// Pulse A: Sweep. GBATEK `SOUND1CNT_L`
-pub const PULSE_A_SWEEP: VolAddress<SweepSetting> = unsafe { VolAddress::new(0x400_0060) };
+pub const PULSE_A_SWEEP: VolAddress<Sweep> = unsafe { VolAddress::new(0x400_0060) };
 
 /// Pulse A: Duty, Length, and Envelope. GBATEK `SOUND1CNT_H`
-pub const PULSE_A_EFFECTS: VolAddress<DutyLenEnvelopeSetting> =
-  unsafe { VolAddress::new(0x400_0062) };
+pub const PULSE_A_EFFECTS: VolAddress<DutyLenEnvelope> = unsafe { VolAddress::new(0x400_0062) };
 
 /// Pulse A: Frequency and Master Control. GBATEK `SOUND1CNT_X`
-pub const PULSE_A_FREQ_CTRL: VolAddress<PulseFrequencyControlSetting> =
+pub const PULSE_A_FREQ_CTRL: VolAddress<PulseFrequencyControl> =
   unsafe { VolAddress::new(0x400_0064) };
 
 //
 
 /// Pulse B: Duty, Length, and Envelope. GBATEK `SOUND2CNT_L`
-pub const PULSE_B_EFFECTS: VolAddress<DutyLenEnvelopeSetting> =
-  unsafe { VolAddress::new(0x400_0068) };
+pub const PULSE_B_EFFECTS: VolAddress<DutyLenEnvelope> = unsafe { VolAddress::new(0x400_0068) };
 
 /// Pulse B: Frequency and Master Control. GBATEK `SOUND2CNT_H`
-pub const PULSE_B_FREQ_CTRL: VolAddress<PulseFrequencyControlSetting> =
+pub const PULSE_B_FREQ_CTRL: VolAddress<PulseFrequencyControl> =
   unsafe { VolAddress::new(0x400_006C) };
 
 //
@@ -32,8 +30,7 @@ pub const WAVE_INIT_RAM_CTRL: VolAddress<WaveInitRAMControl> =
   unsafe { VolAddress::new(0x400_0070) };
 
 /// Wave: Length and Volume. GBATEK `SOUND3CNT_H`
-pub const WAVE_LENGTH_VOLUME: VolAddress<WaveLengthVolumeSetting> =
-  unsafe { VolAddress::new(0x400_0072) };
+pub const WAVE_LENGTH_VOLUME: VolAddress<WaveLengthVolume> = unsafe { VolAddress::new(0x400_0072) };
 
 /// Wave: Frequency and Master Control. GBATEK `SOUND3CNT_X`
 pub const WAVE_FREQ_CTRL: VolAddress<WaveFrequencyControl> = unsafe { VolAddress::new(0x400_0074) };
@@ -41,16 +38,17 @@ pub const WAVE_FREQ_CTRL: VolAddress<WaveFrequencyControl> = unsafe { VolAddress
 //
 
 /// Noise: Length and Envelope. GBATEK `SOUND4CNT_L`
-pub const NOISE_LENGTH_ENVELOPE: VolAddress<LengthEnvelopeSetting> =
+pub const NOISE_LENGTH_ENVELOPE: VolAddress<LengthEnvelope> =
   unsafe { VolAddress::new(0x400_0078) };
 
 /// Noise: Frequency and Master Control. GBATEK `SOUND4CNT_H`
-pub const NOISE_FREQUENCY: VolAddress<NoiseFrequencyControl> = unsafe { VolAddress::new(0x400_007C) };
+pub const NOISE_FREQUENCY: VolAddress<NoiseFrequencyControl> =
+  unsafe { VolAddress::new(0x400_007C) };
 
 //
 
 /// Stereo Controls. GBATEK `SOUNDCNT_L`.
-pub const STERO_CONTROL: VolAddress<StereoControl> = unsafe { VolAddress::new(0x400_0080) };
+pub const STEREO_CONTROL: VolAddress<StereoControl> = unsafe { VolAddress::new(0x400_0080) };
 
 /// Controls DMA sound mixing. GBATEK `SOUNDCNT_H`.
 pub const DMA_MIXER: VolAddress<DMAMixer> = unsafe { VolAddress::new(0x400_0082) };
@@ -58,18 +56,19 @@ pub const DMA_MIXER: VolAddress<DMAMixer> = unsafe { VolAddress::new(0x400_0082)
 /// Sound status and sound master enable.
 ///
 /// If sound is not enabled via this register, most sound registers are reset
-/// (if active) and unaccesable. The exceptions are `DMA_MIXER` and `SOUNDBIAS`.
-pub const SOUND_STATUS_ENABLE: VolAddress<SoundStatusMaster> = unsafe { VolAddress::new(0x400_0084) };
+/// (if active) and unaccessible. The exceptions are `DMA_MIXER` and `SOUNDBIAS`.
+pub const SOUND_STATUS_ENABLE: VolAddress<SoundStatusMaster> =
+  unsafe { VolAddress::new(0x400_0084) };
 
 //
 
 /// Controls final sound output. You can usually leave this at default.
 pub const SOUNDBIAS: VolAddress<Soundbias> = unsafe { VolAddress::new(0x400_0088) };
 
-/// The programmer-accessable wave ram data.
+/// The programmer-accessible wave ram data.
 ///
 /// Note that there are two wave ram banks. At any given moment one of them is
-/// set for use as playback, and the other one will be accessable here. The
+/// set for use as playback, and the other one will be accessible here. The
 /// playback bank is played by playing 4 bits as a single sample and then
 /// rotating the entire 128 bits of wave ram to put the next sample in place.
 /// Thus, when updating the wave ram you generally have to re-write all of the
@@ -87,6 +86,6 @@ pub const WAVE_RAM: VolBlock<u16, U8> = unsafe { VolBlock::new(0x400_0090) };
 pub const FIFO_A: WOVolAddress<[i8; 4]> = unsafe { WOVolAddress::new(0x400_00A0) };
 
 /// Input for DMA Sound Channel B.
-/// 
+///
 /// As `FIFO_A`, but for DMA Sound B
 pub const FIFO_B: WOVolAddress<[i8; 4]> = unsafe { WOVolAddress::new(0x400_00A4) };


### PR DESCRIPTION
* Remove redundant word "Setting" from all the newtype names.
* Add all DMA registers in a safe way.
* New DMA addresses are listed using `0xA_BBB_CCC` style to try it out.